### PR TITLE
Add non-polymorphic transactWrite APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,7 +356,12 @@ let entryList: [TestTypeAWriteEntry] = [
 ]
         
 try await table.bulkWrite(entryList)
-//try await table.transactWrite(entryList)  <<-- When implemented
+```
+
+Or alternatively executed within a DynamoDB transaction-
+
+```swift
+try await table.transactWrite(entryList)
 ```
 
 and similarly for polymorphic queries-
@@ -384,20 +389,29 @@ let entryList: [TestPolymorphicWriteEntry] = [
 ]
         
 try await table.polymorphicBulkWrite(entryList)
+```
+
+Or alternatively executed within a DynamoDB transaction-
+
+```swift
 try await table.polymorphicTransactWrite(entryList)
 ```
 
 For transactions, you can additionally specify a set of constraints to be part of the transaction-
 
 ```swift
-typealias TestTypeAStandardTransactionConstraintEntry = StandardTransactionConstraintEntry<TestTypeA>
+let constraintList: [StandardTransactionConstraintEntry<TestTypeA>] = [
+    .required(existing: databaseItem3),
+    .required(existing: databaseItem4),
+]
 
-// Update when `transactWrite` API implemented
+try await table.transactWrite(entryList, constraints: constraintList)
 ```
 
 and similarly for polymorphic queries-
 
 ```swift
+typealias TestTypeAStandardTransactionConstraintEntry = StandardTransactionConstraintEntry<TestTypeA>
 typealias TestTypeBStandardTransactionConstraintEntry = StandardTransactionConstraintEntry<TestTypeB>
 
 enum TestPolymorphicTransactionConstraintEntry: PolymorphicTransactionConstraintEntry {

--- a/Sources/DynamoDBTables/DynamoDBCompositePrimaryKeyTable.swift
+++ b/Sources/DynamoDBTables/DynamoDBCompositePrimaryKeyTable.swift
@@ -137,6 +137,8 @@ public protocol DynamoDBCompositePrimaryKeyTable {
      * The transaction will comprise of the write entries specified in `entries`.
      * The transaction will fail if the number of entries is greater than 100.
      */
+    func transactWrite<AttributesType, ItemType>(_ entries: [WriteEntry<AttributesType, ItemType>]) async throws
+
     func polymorphicTransactWrite<WriteEntryType: PolymorphicWriteEntry>(
         _ entries: [WriteEntryType]) async throws
 
@@ -147,6 +149,9 @@ public protocol DynamoDBCompositePrimaryKeyTable {
      * with a specified version must exist regardless of if it will be written to by the transaction).
      * The transaction will fail if the number of entries and constraints combined is greater than 100.
      */
+    func transactWrite<AttributesType, ItemType>(
+        _ entries: [WriteEntry<AttributesType, ItemType>], constraints: [TransactionConstraintEntry<AttributesType, ItemType>]) async throws
+
     func polymorphicTransactWrite<WriteEntryType: PolymorphicWriteEntry, TransactionConstraintEntryType: PolymorphicTransactionConstraintEntry>(
         _ entries: [WriteEntryType], constraints: [TransactionConstraintEntryType]) async throws
 

--- a/Sources/DynamoDBTables/InMemoryDynamoDBCompositePrimaryKeyTableWithIndex.swift
+++ b/Sources/DynamoDBTables/InMemoryDynamoDBCompositePrimaryKeyTableWithIndex.swift
@@ -76,6 +76,16 @@ public struct InMemoryDynamoDBCompositePrimaryKeyTableWithIndex<GSILogic: Dynamo
         try await self.gsiLogic.onUpdateItem(newItem: newItem, existingItem: existingItem, gsiDataStore: self.gsiDataStore)
     }
 
+    public func transactWrite(_ entries: [WriteEntry<some Any, some Any>]) async throws {
+        try await self.primaryTable.transactWrite(entries)
+    }
+
+    public func transactWrite<AttributesType, ItemType>(_ entries: [WriteEntry<AttributesType, ItemType>],
+                                                        constraints: [TransactionConstraintEntry<AttributesType, ItemType>]) async throws
+    {
+        try await self.primaryTable.transactWrite(entries, constraints: constraints)
+    }
+
     public func polymorphicTransactWrite(_ entries: [some PolymorphicWriteEntry]) async throws {
         try await self.primaryTable.polymorphicTransactWrite(entries)
     }

--- a/Sources/DynamoDBTables/PolymorphicWriteEntry.swift
+++ b/Sources/DynamoDBTables/PolymorphicWriteEntry.swift
@@ -60,6 +60,13 @@ public typealias StandardTransactionConstraintEntry<ItemType: Codable> = Transac
 
 public enum TransactionConstraintEntry<AttributesType: PrimaryKeyAttributes, ItemType: Sendable & Codable>: Sendable {
     case required(existing: TypedDatabaseItem<AttributesType, ItemType>)
+
+    public var compositePrimaryKey: CompositePrimaryKey<AttributesType> {
+        switch self {
+        case let .required(existing: existing):
+            return existing.compositePrimaryKey
+        }
+    }
 }
 
 // Conforming types are provided by the application to express the different possible constraint entries

--- a/Sources/DynamoDBTables/SimulateConcurrencyDynamoDBCompositePrimaryKeyTable.swift
+++ b/Sources/DynamoDBTables/SimulateConcurrencyDynamoDBCompositePrimaryKeyTable.swift
@@ -106,6 +106,16 @@ public class SimulateConcurrencyDynamoDBCompositePrimaryKeyTable: DynamoDBCompos
         try await self.wrappedDynamoDBTable.updateItem(newItem: newItem, existingItem: existingItem)
     }
 
+    public func transactWrite(_ entries: [WriteEntry<some Any, some Any>]) async throws {
+        try await self.wrappedDynamoDBTable.transactWrite(entries)
+    }
+
+    public func transactWrite<AttributesType, ItemType>(_ entries: [WriteEntry<AttributesType, ItemType>],
+                                                        constraints: [TransactionConstraintEntry<AttributesType, ItemType>]) async throws
+    {
+        try await self.wrappedDynamoDBTable.transactWrite(entries, constraints: constraints)
+    }
+
     public func polymorphicTransactWrite(_ entries: [some PolymorphicWriteEntry]) async throws {
         try await self.wrappedDynamoDBTable.polymorphicTransactWrite(entries)
     }


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:* Add `transactWrite` APIs to provide non-polymorphic bulk APIs executed within a transaction. This API family is missing, requiring users who want to use transactions to use the `polymorphicTransactWrite` API family.

This new API family provides a simpler API to the existing family (themselves also recently renamed from `transactWrite` in #22 to preference non-polymorphic APIs) and to match the existing pattern of `bulkWrite` and `polymorphicBulkWrite` API families that provide non-polymorphic and polymorphic bulk APIs not using a transaction respectively.

Most of the code added mirrors that backing the `polymorphicTransactWrite` API adjusted to handle a single type.

Added unit tests to mirror those existing for `polymorphicTransactWrite`.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
