### PR TITLE
Anchor @PolymorphicWriteEntry diagnostics at the user's case declaration

### DIFF
--- a/Sources/DynamoDBTables/Macros.swift
+++ b/Sources/DynamoDBTables/Macros.swift
@@ -20,7 +20,9 @@
 @attached(
     extension,
     conformances: PolymorphicWriteEntry,
-    names: named(handle(context:)), named(compositePrimaryKey), arbitrary
+    names: named(handle(context:)),
+    named(compositePrimaryKey),
+    arbitrary
 )
 public macro PolymorphicWriteEntry() =
     #externalMacro(
@@ -31,7 +33,9 @@ public macro PolymorphicWriteEntry() =
 @attached(
     extension,
     conformances: PolymorphicTransactionConstraintEntry,
-    names: named(handle(context:)), named(compositePrimaryKey), arbitrary
+    names: named(handle(context:)),
+    named(compositePrimaryKey),
+    arbitrary
 )
 public macro PolymorphicTransactionConstraintEntry() =
     #externalMacro(

--- a/Sources/DynamoDBTables/Macros.swift
+++ b/Sources/DynamoDBTables/Macros.swift
@@ -17,7 +17,11 @@
 //  DynamoDBTables
 //
 
-@attached(extension, conformances: PolymorphicWriteEntry, names: named(handle(context:)), named(compositePrimaryKey))
+@attached(
+    extension,
+    conformances: PolymorphicWriteEntry,
+    names: named(handle(context:)), named(compositePrimaryKey), arbitrary
+)
 public macro PolymorphicWriteEntry() =
     #externalMacro(
         module: "DynamoDBTablesMacros",
@@ -27,8 +31,7 @@ public macro PolymorphicWriteEntry() =
 @attached(
     extension,
     conformances: PolymorphicTransactionConstraintEntry,
-    names: named(handle(context:)),
-    named(compositePrimaryKey)
+    names: named(handle(context:)), named(compositePrimaryKey), arbitrary
 )
 public macro PolymorphicTransactionConstraintEntry() =
     #externalMacro(

--- a/Sources/DynamoDBTables/PolymorphicWriteEntry.swift
+++ b/Sources/DynamoDBTables/PolymorphicWriteEntry.swift
@@ -151,7 +151,8 @@ extension StandardPolymorphicWriteEntryContext: Sendable where WriteEntryTransfo
 // Internal helpers used by `@PolymorphicWriteEntry` and `@PolymorphicTransactionConstraintEntry`
 // macro expansions to surface compile-time diagnostics at the user's enum case declaration when
 // the case parameter type does not match the expected `WriteEntry<...>` / `TransactionConstraintEntry<...>`
-// shape. Not intended to be called directly from user code.
+// shape. The leading-underscore prefix signals "do not call from user code".
+// swiftlint:disable identifier_name
 public func _assertPolymorphicWriteEntryParameter<
     AttributesType: PrimaryKeyAttributes,
     ItemType: Codable & Sendable,
@@ -163,3 +164,4 @@ public func _assertPolymorphicTransactionConstraintEntryParameter<
     ItemType: Codable & Sendable,
     TimeToLiveAttributesType: TimeToLiveAttributes
 >(_: TransactionConstraintEntry<AttributesType, ItemType, TimeToLiveAttributesType>.Type) {}
+// swiftlint:enable identifier_name

--- a/Sources/DynamoDBTables/PolymorphicWriteEntry.swift
+++ b/Sources/DynamoDBTables/PolymorphicWriteEntry.swift
@@ -147,3 +147,19 @@ where WriteEntryTransformType.TableType == WriteTransactionConstraintType.TableT
 }
 
 extension StandardPolymorphicWriteEntryContext: Sendable where WriteEntryTransformType.TableType: Sendable {}
+
+// Internal helpers used by `@PolymorphicWriteEntry` and `@PolymorphicTransactionConstraintEntry`
+// macro expansions to surface compile-time diagnostics at the user's enum case declaration when
+// the case parameter type does not match the expected `WriteEntry<...>` / `TransactionConstraintEntry<...>`
+// shape. Not intended to be called directly from user code.
+public func _assertPolymorphicWriteEntryParameter<
+    AttributesType: PrimaryKeyAttributes,
+    ItemType: Codable & Sendable,
+    TimeToLiveAttributesType: TimeToLiveAttributes
+>(_: WriteEntry<AttributesType, ItemType, TimeToLiveAttributesType>.Type) {}
+
+public func _assertPolymorphicTransactionConstraintEntryParameter<
+    AttributesType: PrimaryKeyAttributes,
+    ItemType: Codable & Sendable,
+    TimeToLiveAttributesType: TimeToLiveAttributes
+>(_: TransactionConstraintEntry<AttributesType, ItemType, TimeToLiveAttributesType>.Type) {}

--- a/Sources/DynamoDBTablesMacros/BaseEntryMacro.swift
+++ b/Sources/DynamoDBTablesMacros/BaseEntryMacro.swift
@@ -58,22 +58,24 @@ enum BaseEntryDiagnostic<Attributes: CoreMacroAttributes>: String, DiagnosticMes
     }
 }
 
+struct CaseExpansionResult {
+    var hasDiagnostics: Bool
+    var handleCases: SwitchCaseListSyntax
+    var compositePrimaryKeyCases: SwitchCaseListSyntax
+    var assertions: [DeclSyntax]
+}
+
 enum BaseEntryMacro<Attributes: MacroAttributes>: ExtensionMacro {
     private static func getCases(
         caseMembers: [EnumCaseDeclSyntax],
         context: some MacroExpansionContext
-    )
-        -> (
-            hasDiagnostics: Bool,
-            handleCases: SwitchCaseListSyntax,
-            compositePrimaryKeyCases: SwitchCaseListSyntax,
-            assertions: [DeclSyntax]
+    ) -> CaseExpansionResult {
+        var result = CaseExpansionResult(
+            hasDiagnostics: false,
+            handleCases: [],
+            compositePrimaryKeyCases: [],
+            assertions: []
         )
-    {
-        var handleCases: SwitchCaseListSyntax = []
-        var compositePrimaryKeyCases: SwitchCaseListSyntax = []
-        var assertions: [DeclSyntax] = []
-        var hasDiagnostics = false
         for caseMember in caseMembers {
             for element in caseMember.elements {
                 // ensure that the enum case only has one parameter
@@ -83,36 +85,36 @@ enum BaseEntryMacro<Attributes: MacroAttributes>: ExtensionMacro {
                     context.diagnose(
                         .init(node: element, message: BaseEntryDiagnostic<Attributes>.enumCasesMustHaveASingleParameter)
                     )
-                    hasDiagnostics = true
+                    result.hasDiagnostics = true
                     // do nothing for this case
                     continue
                 }
 
-                let handleCaseSyntax = SwitchCaseListSyntax.Element(
-                    """
-                    case let .\(element.name)(writeEntry):
-                        return try context.transform(writeEntry)
-                    """
+                result.handleCases.append(
+                    SwitchCaseListSyntax.Element(
+                        """
+                        case let .\(element.name)(writeEntry):
+                            return try context.transform(writeEntry)
+                        """
+                    )
                 )
 
-                handleCases.append(handleCaseSyntax)
-
-                let compositePrimaryKeyCaseSyntax = SwitchCaseListSyntax.Element(
-                    """
-                    case let .\(element.name)(writeEntry):
-                        return writeEntry.compositePrimaryKey
-                    """
+                result.compositePrimaryKeyCases.append(
+                    SwitchCaseListSyntax.Element(
+                        """
+                        case let .\(element.name)(writeEntry):
+                            return writeEntry.compositePrimaryKey
+                        """
+                    )
                 )
 
-                compositePrimaryKeyCases.append(compositePrimaryKeyCaseSyntax)
-
-                assertions.append(
+                result.assertions.append(
                     self.assertionDecl(for: element, parameter: parameter, in: context)
                 )
             }
         }
 
-        return (hasDiagnostics, handleCases, compositePrimaryKeyCases, assertions)
+        return result
     }
 
     /// Emits a per-case assertion helper that forces a compile-time check that the case parameter type
@@ -190,12 +192,9 @@ enum BaseEntryMacro<Attributes: MacroAttributes>: ExtensionMacro {
             return []
         }
 
-        let (hasDiagnostics, handleCases, compositePrimaryKeyCases, assertions) = self.getCases(
-            caseMembers: caseMembers,
-            context: context
-        )
+        let cases = self.getCases(caseMembers: caseMembers, context: context)
 
-        if hasDiagnostics {
+        if cases.hasDiagnostics {
             return []
         }
 
@@ -210,14 +209,14 @@ enum BaseEntryMacro<Attributes: MacroAttributes>: ExtensionMacro {
                 try FunctionDeclSyntax(
                     "func handle<Context: \(raw: Attributes.contextType)>(context: Context) throws -> Context.\(raw: Attributes.transformType)"
                 ) {
-                    SwitchExprSyntax(subject: ExprSyntax(stringLiteral: "self"), cases: handleCases)
+                    SwitchExprSyntax(subject: ExprSyntax(stringLiteral: "self"), cases: cases.handleCases)
                 }
 
                 try VariableDeclSyntax("var compositePrimaryKey: StandardCompositePrimaryKey") {
-                    SwitchExprSyntax(subject: ExprSyntax(stringLiteral: "self"), cases: compositePrimaryKeyCases)
+                    SwitchExprSyntax(subject: ExprSyntax(stringLiteral: "self"), cases: cases.compositePrimaryKeyCases)
                 }
 
-                for assertion in assertions {
+                for assertion in cases.assertions {
                     assertion
                 }
             }

--- a/Sources/DynamoDBTablesMacros/BaseEntryMacro.swift
+++ b/Sources/DynamoDBTablesMacros/BaseEntryMacro.swift
@@ -31,6 +31,8 @@ protocol MacroAttributes: CoreMacroAttributes {
     static var transformType: String { get }
 
     static var contextType: String { get }
+
+    static var assertHelperName: String { get }
 }
 
 enum BaseEntryDiagnostic<Attributes: CoreMacroAttributes>: String, DiagnosticMessage {
@@ -61,15 +63,23 @@ enum BaseEntryMacro<Attributes: MacroAttributes>: ExtensionMacro {
         caseMembers: [EnumCaseDeclSyntax],
         context: some MacroExpansionContext
     )
-        -> (hasDiagnostics: Bool, handleCases: SwitchCaseListSyntax, compositePrimaryKeyCases: SwitchCaseListSyntax)
+        -> (
+            hasDiagnostics: Bool,
+            handleCases: SwitchCaseListSyntax,
+            compositePrimaryKeyCases: SwitchCaseListSyntax,
+            assertions: [DeclSyntax]
+        )
     {
         var handleCases: SwitchCaseListSyntax = []
         var compositePrimaryKeyCases: SwitchCaseListSyntax = []
+        var assertions: [DeclSyntax] = []
         var hasDiagnostics = false
         for caseMember in caseMembers {
             for element in caseMember.elements {
                 // ensure that the enum case only has one parameter
-                guard let parameterClause = element.parameterClause, parameterClause.parameters.count == 1 else {
+                guard let parameterClause = element.parameterClause, parameterClause.parameters.count == 1,
+                    let parameter = parameterClause.parameters.first
+                else {
                     context.diagnose(
                         .init(node: element, message: BaseEntryDiagnostic<Attributes>.enumCasesMustHaveASingleParameter)
                     )
@@ -77,9 +87,6 @@ enum BaseEntryMacro<Attributes: MacroAttributes>: ExtensionMacro {
                     // do nothing for this case
                     continue
                 }
-
-                // TODO: when made possible by the language, check that the type of the parameter conforms to `WriteEntry` or `TransactionConstraintEntry`
-                // https://github.com/swift-server-community/dynamo-db-tables/issues/38
 
                 let handleCaseSyntax = SwitchCaseListSyntax.Element(
                     """
@@ -98,10 +105,44 @@ enum BaseEntryMacro<Attributes: MacroAttributes>: ExtensionMacro {
                 )
 
                 compositePrimaryKeyCases.append(compositePrimaryKeyCaseSyntax)
+
+                assertions.append(
+                    self.assertionDecl(for: element, parameter: parameter, in: context)
+                )
             }
         }
 
-        return (hasDiagnostics, handleCases, compositePrimaryKeyCases)
+        return (hasDiagnostics, handleCases, compositePrimaryKeyCases, assertions)
+    }
+
+    /// Emits a per-case assertion helper that forces a compile-time check that the case parameter type
+    /// is a `WriteEntry<...>` (or `TransactionConstraintEntry<...>`). When the case has a known source
+    /// location, wraps the call in `#sourceLocation` directives so the diagnostic surfaces at the
+    /// user's enum case declaration rather than at the macro-generated buffer.
+    private static func assertionDecl(
+        for element: EnumCaseElementListSyntax.Element,
+        parameter: EnumCaseParameterListSyntax.Element,
+        in context: some MacroExpansionContext
+    ) -> DeclSyntax {
+        let paramType = parameter.type.trimmedDescription
+        let assertionCall = "\(Attributes.assertHelperName)(\(paramType).self)"
+        let body: String
+        if let location = context.location(of: element) {
+            body = """
+                #sourceLocation(file: \(location.file), line: \(location.line))
+                \(assertionCall)
+                #sourceLocation()
+                """
+        } else {
+            body = assertionCall
+        }
+        return DeclSyntax(
+            stringLiteral: """
+                private static func _assertCase_\(element.name.text)() {
+                    \(body)
+                }
+                """
+        )
     }
 
     static func expansion(
@@ -149,7 +190,7 @@ enum BaseEntryMacro<Attributes: MacroAttributes>: ExtensionMacro {
             return []
         }
 
-        let (hasDiagnostics, handleCases, compositePrimaryKeyCases) = self.getCases(
+        let (hasDiagnostics, handleCases, compositePrimaryKeyCases, assertions) = self.getCases(
             caseMembers: caseMembers,
             context: context
         )
@@ -174,6 +215,10 @@ enum BaseEntryMacro<Attributes: MacroAttributes>: ExtensionMacro {
 
                 try VariableDeclSyntax("var compositePrimaryKey: StandardCompositePrimaryKey") {
                     SwitchExprSyntax(subject: ExprSyntax(stringLiteral: "self"), cases: compositePrimaryKeyCases)
+                }
+
+                for assertion in assertions {
+                    assertion
                 }
             }
         )

--- a/Sources/DynamoDBTablesMacros/PolymorphicTransactionConstraintEntryMacro.swift
+++ b/Sources/DynamoDBTablesMacros/PolymorphicTransactionConstraintEntryMacro.swift
@@ -28,6 +28,8 @@ struct PolymorphicTransactionConstraintEntryMacroAttributes: MacroAttributes {
     static let transformType: String = "WriteTransactionConstraintType"
 
     static let contextType: String = "PolymorphicWriteEntryContext"
+
+    static let assertHelperName: String = "_assertPolymorphicTransactionConstraintEntryParameter"
 }
 
 public enum PolymorphicTransactionConstraintEntryMacro: ExtensionMacro {

--- a/Sources/DynamoDBTablesMacros/PolymorphicWriteEntryMacro.swift
+++ b/Sources/DynamoDBTablesMacros/PolymorphicWriteEntryMacro.swift
@@ -28,6 +28,8 @@ struct PolymorphicWriteEntryMacroAttributes: MacroAttributes {
     static let transformType: String = "WriteEntryTransformType"
 
     static let contextType: String = "PolymorphicWriteEntryContext"
+
+    static let assertHelperName: String = "_assertPolymorphicWriteEntryParameter"
 }
 
 public enum PolymorphicWriteEntryMacro: ExtensionMacro {

--- a/Tests/DynamoDBTablesMacrosTests/PolymorphicTransactionConstraintEntryMacroTests.swift
+++ b/Tests/DynamoDBTablesMacrosTests/PolymorphicTransactionConstraintEntryMacroTests.swift
@@ -32,6 +32,8 @@ final class PolymorphicTransactionConstraintEntryMacroTests: XCTestCase {
         )
     ]
 
+    // See PolymorphicWriteEntryMacroTests for context on why `#sourceLocation` directives
+    // don't appear in the test goldens (test framework returns nil from `location(of:)`).
     func testExpansionWithTwoCases() {
         assertMacroExpansion(
             """
@@ -63,6 +65,12 @@ final class PolymorphicTransactionConstraintEntryMacroTests: XCTestCase {
                         case let .testTypeB(writeEntry):
                             return writeEntry.compositePrimaryKey
                         }
+                    }
+                    private static func _assertCase_testTypeA() {
+                        _assertPolymorphicTransactionConstraintEntryParameter(TestTypeAStandardTransactionConstraintEntry.self)
+                    }
+                    private static func _assertCase_testTypeB() {
+                        _assertPolymorphicTransactionConstraintEntryParameter(TestTypeBStandardTransactionConstraintEntry.self)
                     }
                 }
                 """,

--- a/Tests/DynamoDBTablesMacrosTests/PolymorphicWriteEntryMacroTests.swift
+++ b/Tests/DynamoDBTablesMacrosTests/PolymorphicWriteEntryMacroTests.swift
@@ -32,6 +32,12 @@ final class PolymorphicWriteEntryMacroTests: XCTestCase {
         )
     ]
 
+    // The expansion includes per-case `_assertCase_*` helpers that force a compile-time check
+    // that the case parameter is a `WriteEntry<...>`. In real builds the helpers wrap their
+    // assertion call in `#sourceLocation(file:, line:)` so the diagnostic surfaces at the
+    // user's case declaration; `BasicMacroExpansionContext` (used by `assertMacroExpansion`)
+    // returns nil from `location(of:)` for detached nodes, so the test goldens see the
+    // fallback (no `#sourceLocation` directives) path.
     func testExpansionWithTwoCases() {
         assertMacroExpansion(
             """
@@ -63,6 +69,12 @@ final class PolymorphicWriteEntryMacroTests: XCTestCase {
                         case let .testTypeB(writeEntry):
                             return writeEntry.compositePrimaryKey
                         }
+                    }
+                    private static func _assertCase_testTypeA() {
+                        _assertPolymorphicWriteEntryParameter(TestTypeAWriteEntry.self)
+                    }
+                    private static func _assertCase_testTypeB() {
+                        _assertPolymorphicWriteEntryParameter(TestTypeBWriteEntry.self)
                     }
                 }
                 """,


### PR DESCRIPTION
Anchor @PolymorphicWriteEntry diagnostics at the user's case declaration.

When a case parameter type isn't a WriteEntry<...> / TransactionConstraintEntry<...>, the compile error previously surfaced inside the synthetic macro-expansion buffer with an opaque "no exact matches in call to instance method 'transform'" message. The expansion now emits a per-case `_assertCase_<name>` helper that calls a generically- constrained library function (`_assertPolymorphicWriteEntryParameter` / `_assertPolymorphicTransactionConstraintEntryParameter`), with `#sourceLocation` directives wrapping the call so the diagnostic anchors at the user's case line and reads `cannot convert value of type 'X.Type' to expected argument type 'WriteEntry<...>.Type'`.

@PolymorphicOperationReturnType is unchanged — its existing syntactic check already emits diagnostics via `context.diagnose` at the case node.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
