### PR TITLE
Resolve @PolymorphicOperationReturnType case parameters via the type checker

### DIFF
--- a/Sources/DynamoDBTables/Macros.swift
+++ b/Sources/DynamoDBTables/Macros.swift
@@ -50,9 +50,10 @@ public macro PolymorphicTransactionConstraintEntry() =
     names: named(AttributesType),
     named(TimeToLiveAttributesType),
     named(types),
-    named(getItemKey)
+    named(getItemKey),
+    arbitrary
 )
-public macro PolymorphicOperationReturnType(databaseItemType: String = "StandardTypedDatabaseItem") =
+public macro PolymorphicOperationReturnType() =
     #externalMacro(
         module: "DynamoDBTablesMacros",
         type: "PolymorphicOperationReturnTypeMacro"

--- a/Sources/DynamoDBTables/PolymorphicOperationReturnType.swift
+++ b/Sources/DynamoDBTables/PolymorphicOperationReturnType.swift
@@ -66,6 +66,27 @@ public struct PolymorphicOperationReturnOption<
     }
 }
 
+// Internal protocol used by the `@PolymorphicOperationReturnType` macro to extract the row type
+// of a case parameter via an associated type rather than a syntactic name match. Conforming types
+// (in practice only `TypedTTLDatabaseItem` and its typealiases) expose their carried `RowType` so
+// the macro can emit `<paramType>.RowType.self` and let Swift's type checker resolve typealias
+// chains transparently.
+// swiftlint:disable:next type_name
+public protocol _PolymorphicReturnTypeCaseParameter {
+    associatedtype RowType: Codable & Sendable
+}
+
+extension TypedTTLDatabaseItem: _PolymorphicReturnTypeCaseParameter {}
+
+// Internal helper used by the `@PolymorphicOperationReturnType` macro expansion to surface a
+// compile-time diagnostic at the user's enum case declaration when the case parameter type is not
+// a `TypedTTLDatabaseItem<StandardPrimaryKeyAttributes, _, StandardTimeToLiveAttributes>` (or a
+// typealias thereof). The leading-underscore prefix signals "do not call from user code".
+// swiftlint:disable:next identifier_name
+public func _assertPolymorphicOperationReturnTypeParameter<RowType: Codable & Sendable>(
+    _: TypedTTLDatabaseItem<StandardPrimaryKeyAttributes, RowType, StandardTimeToLiveAttributes>.Type
+) {}
+
 struct ReturnTypeDecodable<ReturnType: PolymorphicOperationReturnType>: Decodable {
     let decodedValue: ReturnType
 

--- a/Sources/DynamoDBTablesMacros/PolymorphicOperationReturnTypeMacro.swift
+++ b/Sources/DynamoDBTablesMacros/PolymorphicOperationReturnTypeMacro.swift
@@ -27,20 +27,16 @@ private struct Attributes: CoreMacroAttributes {
     static let protocolName: String = "PolymorphicOperationReturnType"
 }
 
-private struct BasicDiagnosticMessage: DiagnosticMessage {
-    let message: String
-    let diagnosticID: MessageID
-    let severity: SwiftDiagnostics.DiagnosticSeverity = .error
-
-    init(message: String, rawValue: String) {
-        self.message = message
-        self.diagnosticID = MessageID(domain: "PolymorphicOperationReturnTypeMacro", id: rawValue)
-    }
+private struct OperationReturnTypeCases {
+    var hasDiagnostics: Bool
+    var typesArrayElements: ArrayElementListSyntax
+    var getItemKeyCases: SwitchCaseListSyntax
+    var assertions: [DeclSyntax]
 }
 
 public enum PolymorphicOperationReturnTypeMacro: ExtensionMacro {
     public static func expansion(
-        of node: AttributeSyntax,
+        of _: AttributeSyntax,
         attachedTo declaration: some DeclGroupSyntax,
         providingExtensionsOf type: some TypeSyntaxProtocol,
         conformingTo protocols: [TypeSyntax],
@@ -53,18 +49,6 @@ public enum PolymorphicOperationReturnTypeMacro: ExtensionMacro {
             )
 
             return []
-        }
-
-        let databaseItemType: String
-        let standardDatabaseType = "StandardTypedDatabaseItem"
-        if let arguments = node.arguments, case let .argumentList(argumentList) = arguments,
-            let firstArgument = argumentList.first, argumentList.count == 1,
-            firstArgument.label?.text == "databaseItemType",
-            let expression = firstArgument.expression.as(StringLiteralExprSyntax.self)
-        {
-            databaseItemType = expression.representedLiteralValue ?? standardDatabaseType
-        } else {
-            databaseItemType = standardDatabaseType
         }
 
         let requiresProtocolConformance = protocols.reduce(false) { partialResult, protocolSyntax in
@@ -96,13 +80,9 @@ public enum PolymorphicOperationReturnTypeMacro: ExtensionMacro {
             return []
         }
 
-        let (hasDiagnostics, handleCases, getItemKeyCases) = self.getCases(
-            caseMembers: caseMembers,
-            context: context,
-            databaseItemType: databaseItemType
-        )
+        let cases = self.getCases(caseMembers: caseMembers, context: context)
 
-        if hasDiagnostics {
+        if cases.hasDiagnostics {
             return []
         }
 
@@ -119,7 +99,7 @@ public enum PolymorphicOperationReturnTypeMacro: ExtensionMacro {
 
                 let casesArray = ArrayExprSyntax(
                     leftSquare: .leftSquareToken(),
-                    elements: handleCases,
+                    elements: cases.typesArrayElements,
                     rightSquare: .rightSquareToken()
                 )
 
@@ -129,12 +109,16 @@ public enum PolymorphicOperationReturnTypeMacro: ExtensionMacro {
                     \(casesArray)
                     """
                 )
+
+                for assertion in cases.assertions {
+                    assertion
+                }
             }
         )
 
         let batchCapableExtensionDecl = try self.batchCapableExtension(
             type: type,
-            getItemKeyCases: getItemKeyCases
+            getItemKeyCases: cases.getItemKeyCases
         )
 
         return [extensionDecl, batchCapableExtensionDecl]
@@ -163,72 +147,87 @@ extension PolymorphicOperationReturnTypeMacro {
 
     private static func getCases(
         caseMembers: [EnumCaseDeclSyntax],
-        context: some MacroExpansionContext,
-        databaseItemType: String
-    )
-        -> (hasDiagnostics: Bool, handleCases: ArrayElementListSyntax, getItemKeyCases: SwitchCaseListSyntax)
-    {
-        var handleCases: ArrayElementListSyntax = []
-        var getItemKeyCases: SwitchCaseListSyntax = []
-        var hasDiagnostics = false
+        context: some MacroExpansionContext
+    ) -> OperationReturnTypeCases {
+        var result = OperationReturnTypeCases(
+            hasDiagnostics: false,
+            typesArrayElements: [],
+            getItemKeyCases: [],
+            assertions: []
+        )
         for caseMember in caseMembers {
             for element in caseMember.elements {
                 // ensure that the enum case only has one parameter
-                guard let parameters = element.parameterClause?.parameters,
-                    let parameterType = parameters.first?.type.as(IdentifierTypeSyntax.self),
-                    parameters.count == 1
+                guard let parameters = element.parameterClause?.parameters, parameters.count == 1,
+                    let parameter = parameters.first
                 else {
                     context.diagnose(
                         .init(node: element, message: BaseEntryDiagnostic<Attributes>.enumCasesMustHaveASingleParameter)
                     )
-                    hasDiagnostics = true
+                    result.hasDiagnostics = true
                     // do nothing for this case
                     continue
                 }
 
-                guard parameterType.name.text == databaseItemType,
-                    let firstArgumentType = parameterType.genericArgumentClause?.arguments.first?.argument
-                else {
-                    let message =
-                        "PolymorphicOperationReturnTypeMacro decorated enum cases parameter must be of \(databaseItemType) type."
-                    context.diagnose(
-                        .init(
-                            node: element,
-                            message: BasicDiagnosticMessage(
-                                message: message,
-                                rawValue: "enumCasesMustBeOfTheExpectedType"
+                let paramType = parameter.type.trimmedDescription
+
+                result.typesArrayElements.append(
+                    ArrayElementSyntax(
+                        expression: ExprSyntax(
+                            """
+                            (
+                                \(raw: paramType).RowType.self, .init { .\(element.name)($0) }
                             )
-                        )
+                            """
+                        ),
+                        trailingComma: .commaToken()
                     )
-                    hasDiagnostics = true
-                    // do nothing for this case
-                    continue
-                }
-
-                let handleCaseSyntax = ArrayElementSyntax(
-                    expression: ExprSyntax(
-                        """
-                        (
-                            \(firstArgumentType).self, .init { .\(element.name)($0) }
-                        )
-                        """
-                    ),
-                    trailingComma: .commaToken()
                 )
 
-                handleCases.append(handleCaseSyntax)
-
-                let getItemKeyCaseSyntax = SwitchCaseListSyntax.Element(
-                    """
-                    case let .\(element.name)(databaseItem):
-                        return databaseItem.compositePrimaryKey
-                    """
+                result.getItemKeyCases.append(
+                    SwitchCaseListSyntax.Element(
+                        """
+                        case let .\(element.name)(databaseItem):
+                            return databaseItem.compositePrimaryKey
+                        """
+                    )
                 )
 
-                getItemKeyCases.append(getItemKeyCaseSyntax)
+                result.assertions.append(
+                    self.assertionDecl(for: element, paramType: paramType, in: context)
+                )
             }
         }
 
-        return (hasDiagnostics, handleCases, getItemKeyCases)
+        return result
+    }
+
+    /// Emits a per-case assertion helper that forces a compile-time check that the case parameter type
+    /// is a `TypedTTLDatabaseItem<StandardPrimaryKeyAttributes, _, StandardTimeToLiveAttributes>` (or
+    /// any typealias thereof). When the case has a known source location, wraps the call in
+    /// `#sourceLocation` directives so the diagnostic surfaces at the user's case declaration.
+    private static func assertionDecl(
+        for element: EnumCaseElementListSyntax.Element,
+        paramType: String,
+        in context: some MacroExpansionContext
+    ) -> DeclSyntax {
+        let assertionCall = "_assertPolymorphicOperationReturnTypeParameter(\(paramType).self)"
+        let body: String
+        if let location = context.location(of: element) {
+            body = """
+                #sourceLocation(file: \(location.file), line: \(location.line))
+                \(assertionCall)
+                #sourceLocation()
+                """
+        } else {
+            body = assertionCall
+        }
+        return DeclSyntax(
+            stringLiteral: """
+                private static func _assertCase_\(element.name.text)() {
+                    \(body)
+                }
+                """
+        )
     }
 }

--- a/Tests/DynamoDBTablesMacrosTests/PolymorphicOperationReturnTypeMacroTests.swift
+++ b/Tests/DynamoDBTablesMacrosTests/PolymorphicOperationReturnTypeMacroTests.swift
@@ -32,7 +32,13 @@ final class PolymorphicOperationReturnTypeMacroTests: XCTestCase {
         )
     ]
 
-    func testExpansionWithDefaultDatabaseItemType() {
+    // The expansion includes per-case `_assertCase_*` helpers that force a compile-time check
+    // that the case parameter is a `TypedTTLDatabaseItem<...>` specialization. In real builds the
+    // helpers wrap their assertion call in `#sourceLocation(file:, line:)` so the diagnostic
+    // surfaces at the user's case declaration; `BasicMacroExpansionContext` (used by
+    // `assertMacroExpansion`) returns nil from `location(of:)` for detached nodes, so the test
+    // goldens see the fallback (no `#sourceLocation` directives) path.
+    func testExpansionWithStandardTypedDatabaseItem() {
         assertMacroExpansion(
             """
             @PolymorphicOperationReturnType
@@ -52,14 +58,20 @@ final class PolymorphicOperationReturnTypeMacroTests: XCTestCase {
                     typealias TimeToLiveAttributesType = StandardTimeToLiveAttributes
                     static let types: [(Codable.Type, PolymorphicOperationReturnOption<AttributesType, Self, TimeToLiveAttributesType>)] =
                     [(
-                        TestTypeA.self, .init {
+                        StandardTypedDatabaseItem<TestTypeA>.RowType.self, .init {
                                 .testTypeA($0)
                             }
                         ), (
-                        TestTypeB.self, .init {
+                        StandardTypedDatabaseItem<TestTypeB>.RowType.self, .init {
                                 .testTypeB($0)
                             }
                         ),]
+                    private static func _assertCase_testTypeA() {
+                        _assertPolymorphicOperationReturnTypeParameter(StandardTypedDatabaseItem<TestTypeA>.self)
+                    }
+                    private static func _assertCase_testTypeB() {
+                        _assertPolymorphicOperationReturnTypeParameter(StandardTypedDatabaseItem<TestTypeB>.self)
+                    }
                 }
 
                 extension TestQueryableTypes: BatchCapableReturnType {
@@ -77,17 +89,21 @@ final class PolymorphicOperationReturnTypeMacroTests: XCTestCase {
         )
     }
 
-    func testExpansionWithCustomDatabaseItemType() {
+    // The macro no longer performs a syntactic name check; typealiases that resolve to a
+    // `TypedTTLDatabaseItem<...>` are handled transparently by the type checker via the
+    // `_PolymorphicReturnTypeCaseParameter` protocol. The expanded source mirrors the case
+    // parameter's syntactic form — the row-type is recovered at compile time via `.RowType`.
+    func testExpansionWithUserTypealias() {
         assertMacroExpansion(
             """
-            @PolymorphicOperationReturnType(databaseItemType: "CustomTypedDatabaseItem")
+            @PolymorphicOperationReturnType
             enum TestQueryableTypes {
-                case testTypeA(CustomTypedDatabaseItem<TestTypeA>)
+                case testTypeA(MyAlias<TestTypeA>)
             }
             """,
             expandedSource: """
                 enum TestQueryableTypes {
-                    case testTypeA(CustomTypedDatabaseItem<TestTypeA>)
+                    case testTypeA(MyAlias<TestTypeA>)
                 }
 
                 extension TestQueryableTypes: PolymorphicOperationReturnType {
@@ -95,10 +111,58 @@ final class PolymorphicOperationReturnTypeMacroTests: XCTestCase {
                     typealias TimeToLiveAttributesType = StandardTimeToLiveAttributes
                     static let types: [(Codable.Type, PolymorphicOperationReturnOption<AttributesType, Self, TimeToLiveAttributesType>)] =
                     [(
-                        TestTypeA.self, .init {
+                        MyAlias<TestTypeA>.RowType.self, .init {
                                 .testTypeA($0)
                             }
                         ),]
+                    private static func _assertCase_testTypeA() {
+                        _assertPolymorphicOperationReturnTypeParameter(MyAlias<TestTypeA>.self)
+                    }
+                }
+
+                extension TestQueryableTypes: BatchCapableReturnType {
+                    func getItemKey() -> CompositePrimaryKey<AttributesType> {
+                        switch self {
+                        case let .testTypeA(databaseItem):
+                            return databaseItem.compositePrimaryKey
+                        }
+                    }
+                }
+                """,
+            macroSpecs: macroSpecs
+        )
+    }
+
+    // A typealias that resolves to a fully-specialised `TypedTTLDatabaseItem<...>` with no
+    // remaining generic arguments. The old syntactic check rejected this shape because there
+    // was no `genericArgumentClause` to extract a row type from; the new mechanism resolves
+    // `.RowType` via the protocol conformance on the underlying `TypedTTLDatabaseItem`, so it
+    // works transparently.
+    func testExpansionWithFullyConcreteTypealias() {
+        assertMacroExpansion(
+            """
+            @PolymorphicOperationReturnType
+            enum TestQueryableTypes {
+                case testTypeA(ConcreteAlias)
+            }
+            """,
+            expandedSource: """
+                enum TestQueryableTypes {
+                    case testTypeA(ConcreteAlias)
+                }
+
+                extension TestQueryableTypes: PolymorphicOperationReturnType {
+                    typealias AttributesType = StandardPrimaryKeyAttributes
+                    typealias TimeToLiveAttributesType = StandardTimeToLiveAttributes
+                    static let types: [(Codable.Type, PolymorphicOperationReturnOption<AttributesType, Self, TimeToLiveAttributesType>)] =
+                    [(
+                        ConcreteAlias.RowType.self, .init {
+                                .testTypeA($0)
+                            }
+                        ),]
+                    private static func _assertCase_testTypeA() {
+                        _assertPolymorphicOperationReturnTypeParameter(ConcreteAlias.self)
+                    }
                 }
 
                 extension TestQueryableTypes: BatchCapableReturnType {
@@ -152,31 +216,6 @@ final class PolymorphicOperationReturnTypeMacroTests: XCTestCase {
                     message: "@PolymorphicOperationReturnType decorated enum must be have at least a singe case.",
                     line: 1,
                     column: 1
-                )
-            ],
-            macroSpecs: macroSpecs
-        )
-    }
-
-    func testDiagnosticWhenCaseParameterIsWrongType() {
-        assertMacroExpansion(
-            """
-            @PolymorphicOperationReturnType
-            enum BadTypes {
-                case bad(SomeOtherType<TestTypeA>)
-            }
-            """,
-            expandedSource: """
-                enum BadTypes {
-                    case bad(SomeOtherType<TestTypeA>)
-                }
-                """,
-            diagnostics: [
-                DiagnosticSpec(
-                    message:
-                        "PolymorphicOperationReturnTypeMacro decorated enum cases parameter must be of StandardTypedDatabaseItem type.",
-                    line: 3,
-                    column: 10
                 )
             ],
             macroSpecs: macroSpecs

--- a/Tests/DynamoDBTablesTests/SimulateConcurrencyDynamoDBCompositePrimaryKeyTableTests.swift
+++ b/Tests/DynamoDBTablesTests/SimulateConcurrencyDynamoDBCompositePrimaryKeyTableTests.swift
@@ -32,7 +32,7 @@ private typealias DatabaseRowType = StandardTypedDatabaseItem<TestTypeA>
 
 typealias CustomTypedDatabaseItem = StandardTypedDatabaseItem
 
-@PolymorphicOperationReturnType(databaseItemType: "CustomTypedDatabaseItem")
+@PolymorphicOperationReturnType
 enum ExpectedQueryableTypes {
     case testTypeA(CustomTypedDatabaseItem<TestTypeA>)
 }

--- a/Tests/DynamoDBTablesTests/TestConfiguration.swift
+++ b/Tests/DynamoDBTablesTests/TestConfiguration.swift
@@ -54,9 +54,11 @@ struct TestTypeC: Codable {
     }
 }
 
+typealias TestTypeAItem = StandardTypedDatabaseItem<TestTypeA>
+
 @PolymorphicOperationReturnType
 enum TestQueryableTypes {
-    case testTypeA(StandardTypedDatabaseItem<TestTypeA>)
+    case testTypeA(TestTypeAItem)
     case testTypeB(StandardTypedDatabaseItem<TestTypeB>)
 }
 


### PR DESCRIPTION
Replaced the syntactic name check (and the `databaseItemType:` workaround) with a `_PolymorphicReturnTypeCaseParameter` protocol conformance on `TypedTTLDatabaseItem`. The macro now emits `<paramType>.RowType.self` for the metatype slot in `static let types`, so typealiases — module-qualified, generic, or fully concrete — resolve transparently. Callers that passed `databaseItemType:` should drop the argument.

A per-case `_assertCase_<name>` helper, calling `_assertPolymorphicOperationReturnTypeParameter` wrapped in `#sourceLocation` directives, anchors the compile-time diagnostic at the user's case declaration when the parameter type isn't a `TypedTTLDatabaseItem<StandardPrimaryKeyAttributes, _, StandardTimeToLiveAttributes>`.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
