### PR TITLE
Drop Standard* hardcodes from polymorphic enum macros.

### DIFF
--- a/Sources/DynamoDBTables/PolymorphicOperationReturnType.swift
+++ b/Sources/DynamoDBTables/PolymorphicOperationReturnType.swift
@@ -66,26 +66,21 @@ public struct PolymorphicOperationReturnOption<
     }
 }
 
-// Internal protocol used by the `@PolymorphicOperationReturnType` macro to extract the row type
-// of a case parameter via an associated type rather than a syntactic name match. Conforming types
-// (in practice only `TypedTTLDatabaseItem` and its typealiases) expose their carried `RowType` so
-// the macro can emit `<paramType>.RowType.self` and let Swift's type checker resolve typealias
-// chains transparently.
+// Internal protocol used by the `@PolymorphicOperationReturnType` macro to extract the row, key,
+// and TTL attribute types of a case parameter via associated types rather than syntactic name
+// matching. Conforming types (in practice only `TypedTTLDatabaseItem` and its typealiases) expose
+// these via auto-witnessing — `TypedTTLDatabaseItem`'s generic parameters already share the
+// associated-type names — so the macro can emit `<paramType>.RowType.self`,
+// `<paramType>.AttributesType`, and `<paramType>.TimeToLiveAttributesType` and let Swift's type
+// checker resolve typealias chains transparently.
 // swiftlint:disable:next type_name
 public protocol _PolymorphicReturnTypeCaseParameter {
     associatedtype RowType: Codable & Sendable
+    associatedtype AttributesType: PrimaryKeyAttributes
+    associatedtype TimeToLiveAttributesType: TimeToLiveAttributes
 }
 
 extension TypedTTLDatabaseItem: _PolymorphicReturnTypeCaseParameter {}
-
-// Internal helper used by the `@PolymorphicOperationReturnType` macro expansion to surface a
-// compile-time diagnostic at the user's enum case declaration when the case parameter type is not
-// a `TypedTTLDatabaseItem<StandardPrimaryKeyAttributes, _, StandardTimeToLiveAttributes>` (or a
-// typealias thereof). The leading-underscore prefix signals "do not call from user code".
-// swiftlint:disable:next identifier_name
-public func _assertPolymorphicOperationReturnTypeParameter<RowType: Codable & Sendable>(
-    _: TypedTTLDatabaseItem<StandardPrimaryKeyAttributes, RowType, StandardTimeToLiveAttributes>.Type
-) {}
 
 struct ReturnTypeDecodable<ReturnType: PolymorphicOperationReturnType>: Decodable {
     let decodedValue: ReturnType

--- a/Sources/DynamoDBTables/PolymorphicWriteEntry.swift
+++ b/Sources/DynamoDBTables/PolymorphicWriteEntry.swift
@@ -148,20 +148,21 @@ where WriteEntryTransformType.TableType == WriteTransactionConstraintType.TableT
 
 extension StandardPolymorphicWriteEntryContext: Sendable where WriteEntryTransformType.TableType: Sendable {}
 
-// Internal helpers used by `@PolymorphicWriteEntry` and `@PolymorphicTransactionConstraintEntry`
-// macro expansions to surface compile-time diagnostics at the user's enum case declaration when
-// the case parameter type does not match the expected `WriteEntry<...>` / `TransactionConstraintEntry<...>`
-// shape. The leading-underscore prefix signals "do not call from user code".
-// swiftlint:disable identifier_name
-public func _assertPolymorphicWriteEntryParameter<
-    AttributesType: PrimaryKeyAttributes,
-    ItemType: Codable & Sendable,
-    TimeToLiveAttributesType: TimeToLiveAttributes
->(_: WriteEntry<AttributesType, ItemType, TimeToLiveAttributesType>.Type) {}
+// Internal protocols used by `@PolymorphicWriteEntry` and `@PolymorphicTransactionConstraintEntry`
+// macro expansions to derive the enum-level `AttributesType` from the case parameter type, rather
+// than hardcoding `StandardPrimaryKeyAttributes`. Conforming types (in practice only `WriteEntry`
+// and `TransactionConstraintEntry`) expose their attributes type via auto-witnessing — the generic
+// parameter `AttributesType` on each enum already shares the associated-type name.
+// swiftlint:disable type_name
+public protocol _PolymorphicWriteEntryCaseParameter {
+    associatedtype AttributesType: PrimaryKeyAttributes
+}
 
-public func _assertPolymorphicTransactionConstraintEntryParameter<
-    AttributesType: PrimaryKeyAttributes,
-    ItemType: Codable & Sendable,
-    TimeToLiveAttributesType: TimeToLiveAttributes
->(_: TransactionConstraintEntry<AttributesType, ItemType, TimeToLiveAttributesType>.Type) {}
-// swiftlint:enable identifier_name
+public protocol _PolymorphicTransactionConstraintEntryCaseParameter {
+    associatedtype AttributesType: PrimaryKeyAttributes
+}
+// swiftlint:enable type_name
+
+extension WriteEntry: _PolymorphicWriteEntryCaseParameter {}
+
+extension TransactionConstraintEntry: _PolymorphicTransactionConstraintEntryCaseParameter {}

--- a/Sources/DynamoDBTablesMacros/BaseEntryMacro.swift
+++ b/Sources/DynamoDBTablesMacros/BaseEntryMacro.swift
@@ -32,7 +32,10 @@ protocol MacroAttributes: CoreMacroAttributes {
 
     static var contextType: String { get }
 
-    static var assertHelperName: String { get }
+    /// The name of the concrete case-parameter base type (e.g. `"WriteEntry"`). Used inside the
+    /// generated per-case assertion to pin the parameter type's `AttributesType` to the enum's
+    /// derived `AttributesType` typealias.
+    static var caseParameterBaseTypeName: String { get }
 }
 
 enum BaseEntryDiagnostic<Attributes: CoreMacroAttributes>: String, DiagnosticMessage {
@@ -60,6 +63,7 @@ enum BaseEntryDiagnostic<Attributes: CoreMacroAttributes>: String, DiagnosticMes
 
 struct CaseExpansionResult {
     var hasDiagnostics: Bool
+    var firstParameterType: String?
     var handleCases: SwitchCaseListSyntax
     var compositePrimaryKeyCases: SwitchCaseListSyntax
     var assertions: [DeclSyntax]
@@ -72,6 +76,7 @@ enum BaseEntryMacro<Attributes: MacroAttributes>: ExtensionMacro {
     ) -> CaseExpansionResult {
         var result = CaseExpansionResult(
             hasDiagnostics: false,
+            firstParameterType: nil,
             handleCases: [],
             compositePrimaryKeyCases: [],
             assertions: []
@@ -88,6 +93,10 @@ enum BaseEntryMacro<Attributes: MacroAttributes>: ExtensionMacro {
                     result.hasDiagnostics = true
                     // do nothing for this case
                     continue
+                }
+
+                if result.firstParameterType == nil {
+                    result.firstParameterType = parameter.type.trimmedDescription
                 }
 
                 result.handleCases.append(
@@ -118,30 +127,42 @@ enum BaseEntryMacro<Attributes: MacroAttributes>: ExtensionMacro {
     }
 
     /// Emits a per-case assertion helper that forces a compile-time check that the case parameter type
-    /// is a `WriteEntry<...>` (or `TransactionConstraintEntry<...>`). When the case has a known source
-    /// location, wraps the call in `#sourceLocation` directives so the diagnostic surfaces at the
-    /// user's enum case declaration rather than at the macro-generated buffer.
+    /// is a `<BaseType><AttributesType, _, _>` — both confirming the parameter shape and that the
+    /// case's attributes match the enum's derived `AttributesType` typealias. When the case has a
+    /// known source location, wraps the call in `#sourceLocation` directives so the diagnostic
+    /// surfaces at the user's enum case declaration rather than at the macro-generated buffer.
     private static func assertionDecl(
         for element: EnumCaseElementListSyntax.Element,
         parameter: EnumCaseParameterListSyntax.Element,
         in context: some MacroExpansionContext
     ) -> DeclSyntax {
         let paramType = parameter.type.trimmedDescription
-        let assertionCall = "\(Attributes.assertHelperName)(\(paramType).self)"
-        let body: String
+        // The pretty-printer splits multi-line declarations across lines, so the
+        // `#sourceLocation` directive is placed immediately before the `_check` call site
+        // (where any diagnostic actually fires) rather than at the top of the body — that
+        // way the directive's line offset doesn't drift through the function declaration.
+        let assertionBody: String
         if let location = context.location(of: element) {
-            body = """
+            assertionBody = """
+                func _check<R: Codable & Sendable, T: TimeToLiveAttributes>(
+                    _: \(Attributes.caseParameterBaseTypeName)<AttributesType, R, T>.Type
+                ) {}
                 #sourceLocation(file: \(location.file), line: \(location.line))
-                \(assertionCall)
+                _check(\(paramType).self)
                 #sourceLocation()
                 """
         } else {
-            body = assertionCall
+            assertionBody = """
+                func _check<R: Codable & Sendable, T: TimeToLiveAttributes>(
+                    _: \(Attributes.caseParameterBaseTypeName)<AttributesType, R, T>.Type
+                ) {}
+                _check(\(paramType).self)
+                """
         }
         return DeclSyntax(
             stringLiteral: """
                 private static func _assertCase_\(element.name.text)() {
-                    \(body)
+                    \(assertionBody)
                 }
                 """
         )
@@ -198,6 +219,12 @@ enum BaseEntryMacro<Attributes: MacroAttributes>: ExtensionMacro {
             return []
         }
 
+        // The enum-level `AttributesType` is derived from the first case's parameter type. Subsequent
+        // cases are verified to have the same `AttributesType` via the per-case assertion helpers.
+        guard let firstParameterType = cases.firstParameterType else {
+            return []
+        }
+
         let type = TypeSyntax(
             extendedGraphemeClusterLiteral: requiresProtocolConformance
                 ? "\(type.trimmed): \(Attributes.protocolName) "
@@ -206,13 +233,17 @@ enum BaseEntryMacro<Attributes: MacroAttributes>: ExtensionMacro {
         let extensionDecl = try ExtensionDeclSyntax(
             extendedType: type,
             memberBlockBuilder: {
+                try TypeAliasDeclSyntax(
+                    "typealias AttributesType = \(raw: firstParameterType).AttributesType"
+                )
+
                 try FunctionDeclSyntax(
                     "func handle<Context: \(raw: Attributes.contextType)>(context: Context) throws -> Context.\(raw: Attributes.transformType)"
                 ) {
                     SwitchExprSyntax(subject: ExprSyntax(stringLiteral: "self"), cases: cases.handleCases)
                 }
 
-                try VariableDeclSyntax("var compositePrimaryKey: StandardCompositePrimaryKey") {
+                try VariableDeclSyntax("var compositePrimaryKey: CompositePrimaryKey<AttributesType>") {
                     SwitchExprSyntax(subject: ExprSyntax(stringLiteral: "self"), cases: cases.compositePrimaryKeyCases)
                 }
 

--- a/Sources/DynamoDBTablesMacros/PolymorphicOperationReturnTypeMacro.swift
+++ b/Sources/DynamoDBTablesMacros/PolymorphicOperationReturnTypeMacro.swift
@@ -29,6 +29,7 @@ private struct Attributes: CoreMacroAttributes {
 
 private struct OperationReturnTypeCases {
     var hasDiagnostics: Bool
+    var firstParameterType: String?
     var typesArrayElements: ArrayElementListSyntax
     var getItemKeyCases: SwitchCaseListSyntax
     var assertions: [DeclSyntax]
@@ -86,6 +87,13 @@ public enum PolymorphicOperationReturnTypeMacro: ExtensionMacro {
             return []
         }
 
+        // The enum-level `AttributesType` and `TimeToLiveAttributesType` are derived from the first
+        // case's parameter type. Subsequent cases are verified to share these via the per-case
+        // assertion helpers.
+        guard let firstParameterType = cases.firstParameterType else {
+            return []
+        }
+
         let polymorphicType = TypeSyntax(
             extendedGraphemeClusterLiteral: requiresProtocolConformance
                 ? "\(type.trimmed): \(Attributes.protocolName) "
@@ -94,8 +102,12 @@ public enum PolymorphicOperationReturnTypeMacro: ExtensionMacro {
         let extensionDecl = try ExtensionDeclSyntax(
             extendedType: polymorphicType,
             memberBlockBuilder: {
-                try TypeAliasDeclSyntax("typealias AttributesType = StandardPrimaryKeyAttributes")
-                try TypeAliasDeclSyntax("typealias TimeToLiveAttributesType = StandardTimeToLiveAttributes")
+                try TypeAliasDeclSyntax(
+                    "typealias AttributesType = \(raw: firstParameterType).AttributesType"
+                )
+                try TypeAliasDeclSyntax(
+                    "typealias TimeToLiveAttributesType = \(raw: firstParameterType).TimeToLiveAttributesType"
+                )
 
                 let casesArray = ArrayExprSyntax(
                     leftSquare: .leftSquareToken(),
@@ -151,6 +163,7 @@ extension PolymorphicOperationReturnTypeMacro {
     ) -> OperationReturnTypeCases {
         var result = OperationReturnTypeCases(
             hasDiagnostics: false,
+            firstParameterType: nil,
             typesArrayElements: [],
             getItemKeyCases: [],
             assertions: []
@@ -170,6 +183,10 @@ extension PolymorphicOperationReturnTypeMacro {
                 }
 
                 let paramType = parameter.type.trimmedDescription
+
+                if result.firstParameterType == nil {
+                    result.firstParameterType = paramType
+                }
 
                 result.typesArrayElements.append(
                     ArrayElementSyntax(
@@ -203,29 +220,41 @@ extension PolymorphicOperationReturnTypeMacro {
     }
 
     /// Emits a per-case assertion helper that forces a compile-time check that the case parameter type
-    /// is a `TypedTTLDatabaseItem<StandardPrimaryKeyAttributes, _, StandardTimeToLiveAttributes>` (or
-    /// any typealias thereof). When the case has a known source location, wraps the call in
-    /// `#sourceLocation` directives so the diagnostic surfaces at the user's case declaration.
+    /// is a `TypedTTLDatabaseItem<AttributesType, _, TimeToLiveAttributesType>` — both confirming the
+    /// parameter shape and that the case's attributes/TTL match the enum's derived typealiases. When
+    /// the case has a known source location, wraps the call in `#sourceLocation` directives so the
+    /// diagnostic surfaces at the user's case declaration.
     private static func assertionDecl(
         for element: EnumCaseElementListSyntax.Element,
         paramType: String,
         in context: some MacroExpansionContext
     ) -> DeclSyntax {
-        let assertionCall = "_assertPolymorphicOperationReturnTypeParameter(\(paramType).self)"
-        let body: String
+        // The pretty-printer splits multi-line declarations across lines, so the
+        // `#sourceLocation` directive is placed immediately before the `_check` call site
+        // (where any diagnostic actually fires) rather than at the top of the body — that
+        // way the directive's line offset doesn't drift through the function declaration.
+        let assertionBody: String
         if let location = context.location(of: element) {
-            body = """
+            assertionBody = """
+                func _check<R: Codable & Sendable>(
+                    _: TypedTTLDatabaseItem<AttributesType, R, TimeToLiveAttributesType>.Type
+                ) {}
                 #sourceLocation(file: \(location.file), line: \(location.line))
-                \(assertionCall)
+                _check(\(paramType).self)
                 #sourceLocation()
                 """
         } else {
-            body = assertionCall
+            assertionBody = """
+                func _check<R: Codable & Sendable>(
+                    _: TypedTTLDatabaseItem<AttributesType, R, TimeToLiveAttributesType>.Type
+                ) {}
+                _check(\(paramType).self)
+                """
         }
         return DeclSyntax(
             stringLiteral: """
                 private static func _assertCase_\(element.name.text)() {
-                    \(body)
+                    \(assertionBody)
                 }
                 """
         )

--- a/Sources/DynamoDBTablesMacros/PolymorphicTransactionConstraintEntryMacro.swift
+++ b/Sources/DynamoDBTablesMacros/PolymorphicTransactionConstraintEntryMacro.swift
@@ -29,7 +29,7 @@ struct PolymorphicTransactionConstraintEntryMacroAttributes: MacroAttributes {
 
     static let contextType: String = "PolymorphicWriteEntryContext"
 
-    static let assertHelperName: String = "_assertPolymorphicTransactionConstraintEntryParameter"
+    static let caseParameterBaseTypeName: String = "TransactionConstraintEntry"
 }
 
 public enum PolymorphicTransactionConstraintEntryMacro: ExtensionMacro {

--- a/Sources/DynamoDBTablesMacros/PolymorphicWriteEntryMacro.swift
+++ b/Sources/DynamoDBTablesMacros/PolymorphicWriteEntryMacro.swift
@@ -29,7 +29,7 @@ struct PolymorphicWriteEntryMacroAttributes: MacroAttributes {
 
     static let contextType: String = "PolymorphicWriteEntryContext"
 
-    static let assertHelperName: String = "_assertPolymorphicWriteEntryParameter"
+    static let caseParameterBaseTypeName: String = "WriteEntry"
 }
 
 public enum PolymorphicWriteEntryMacro: ExtensionMacro {

--- a/Tests/DynamoDBTablesMacrosTests/PolymorphicOperationReturnTypeMacroTests.swift
+++ b/Tests/DynamoDBTablesMacrosTests/PolymorphicOperationReturnTypeMacroTests.swift
@@ -32,12 +32,14 @@ final class PolymorphicOperationReturnTypeMacroTests: XCTestCase {
         )
     ]
 
-    // The expansion includes per-case `_assertCase_*` helpers that force a compile-time check
-    // that the case parameter is a `TypedTTLDatabaseItem<...>` specialization. In real builds the
-    // helpers wrap their assertion call in `#sourceLocation(file:, line:)` so the diagnostic
-    // surfaces at the user's case declaration; `BasicMacroExpansionContext` (used by
-    // `assertMacroExpansion`) returns nil from `location(of:)` for detached nodes, so the test
-    // goldens see the fallback (no `#sourceLocation` directives) path.
+    // The expansion derives both `AttributesType` and `TimeToLiveAttributesType` from the first
+    // case's parameter type and emits per-case `_assertCase_*` helpers that pin each case
+    // parameter to `TypedTTLDatabaseItem<AttributesType, _, TimeToLiveAttributesType>`. The pin
+    // catches both "wrong parameter shape" and "case attributes/TTL don't match the enum's" at
+    // the user's case declaration. In real builds the helpers wrap their assertion in
+    // `#sourceLocation(file:, line:)`; `BasicMacroExpansionContext` (used by `assertMacroExpansion`)
+    // returns nil from `location(of:)` for detached nodes, so the test goldens see the
+    // fallback (no `#sourceLocation` directives) path.
     func testExpansionWithStandardTypedDatabaseItem() {
         assertMacroExpansion(
             """
@@ -54,8 +56,8 @@ final class PolymorphicOperationReturnTypeMacroTests: XCTestCase {
                 }
 
                 extension TestQueryableTypes: PolymorphicOperationReturnType {
-                    typealias AttributesType = StandardPrimaryKeyAttributes
-                    typealias TimeToLiveAttributesType = StandardTimeToLiveAttributes
+                    typealias AttributesType = StandardTypedDatabaseItem<TestTypeA>.AttributesType
+                    typealias TimeToLiveAttributesType = StandardTypedDatabaseItem<TestTypeA>.TimeToLiveAttributesType
                     static let types: [(Codable.Type, PolymorphicOperationReturnOption<AttributesType, Self, TimeToLiveAttributesType>)] =
                     [(
                         StandardTypedDatabaseItem<TestTypeA>.RowType.self, .init {
@@ -67,10 +69,18 @@ final class PolymorphicOperationReturnTypeMacroTests: XCTestCase {
                             }
                         ),]
                     private static func _assertCase_testTypeA() {
-                        _assertPolymorphicOperationReturnTypeParameter(StandardTypedDatabaseItem<TestTypeA>.self)
+                        func _check<R: Codable & Sendable>(
+                        _: TypedTTLDatabaseItem<AttributesType, R, TimeToLiveAttributesType>.Type
+                        ) {
+                        }
+                        _check(StandardTypedDatabaseItem<TestTypeA>.self)
                     }
                     private static func _assertCase_testTypeB() {
-                        _assertPolymorphicOperationReturnTypeParameter(StandardTypedDatabaseItem<TestTypeB>.self)
+                        func _check<R: Codable & Sendable>(
+                        _: TypedTTLDatabaseItem<AttributesType, R, TimeToLiveAttributesType>.Type
+                        ) {
+                        }
+                        _check(StandardTypedDatabaseItem<TestTypeB>.self)
                     }
                 }
 
@@ -107,8 +117,8 @@ final class PolymorphicOperationReturnTypeMacroTests: XCTestCase {
                 }
 
                 extension TestQueryableTypes: PolymorphicOperationReturnType {
-                    typealias AttributesType = StandardPrimaryKeyAttributes
-                    typealias TimeToLiveAttributesType = StandardTimeToLiveAttributes
+                    typealias AttributesType = MyAlias<TestTypeA>.AttributesType
+                    typealias TimeToLiveAttributesType = MyAlias<TestTypeA>.TimeToLiveAttributesType
                     static let types: [(Codable.Type, PolymorphicOperationReturnOption<AttributesType, Self, TimeToLiveAttributesType>)] =
                     [(
                         MyAlias<TestTypeA>.RowType.self, .init {
@@ -116,7 +126,11 @@ final class PolymorphicOperationReturnTypeMacroTests: XCTestCase {
                             }
                         ),]
                     private static func _assertCase_testTypeA() {
-                        _assertPolymorphicOperationReturnTypeParameter(MyAlias<TestTypeA>.self)
+                        func _check<R: Codable & Sendable>(
+                        _: TypedTTLDatabaseItem<AttributesType, R, TimeToLiveAttributesType>.Type
+                        ) {
+                        }
+                        _check(MyAlias<TestTypeA>.self)
                     }
                 }
 
@@ -152,8 +166,8 @@ final class PolymorphicOperationReturnTypeMacroTests: XCTestCase {
                 }
 
                 extension TestQueryableTypes: PolymorphicOperationReturnType {
-                    typealias AttributesType = StandardPrimaryKeyAttributes
-                    typealias TimeToLiveAttributesType = StandardTimeToLiveAttributes
+                    typealias AttributesType = ConcreteAlias.AttributesType
+                    typealias TimeToLiveAttributesType = ConcreteAlias.TimeToLiveAttributesType
                     static let types: [(Codable.Type, PolymorphicOperationReturnOption<AttributesType, Self, TimeToLiveAttributesType>)] =
                     [(
                         ConcreteAlias.RowType.self, .init {
@@ -161,7 +175,11 @@ final class PolymorphicOperationReturnTypeMacroTests: XCTestCase {
                             }
                         ),]
                     private static func _assertCase_testTypeA() {
-                        _assertPolymorphicOperationReturnTypeParameter(ConcreteAlias.self)
+                        func _check<R: Codable & Sendable>(
+                        _: TypedTTLDatabaseItem<AttributesType, R, TimeToLiveAttributesType>.Type
+                        ) {
+                        }
+                        _check(ConcreteAlias.self)
                     }
                 }
 

--- a/Tests/DynamoDBTablesMacrosTests/PolymorphicTransactionConstraintEntryMacroTests.swift
+++ b/Tests/DynamoDBTablesMacrosTests/PolymorphicTransactionConstraintEntryMacroTests.swift
@@ -32,8 +32,8 @@ final class PolymorphicTransactionConstraintEntryMacroTests: XCTestCase {
         )
     ]
 
-    // See PolymorphicWriteEntryMacroTests for context on why `#sourceLocation` directives
-    // don't appear in the test goldens (test framework returns nil from `location(of:)`).
+    // See PolymorphicWriteEntryMacroTests for context on the `AttributesType` derivation and
+    // why `#sourceLocation` directives don't appear in the test goldens.
     func testExpansionWithTwoCases() {
         assertMacroExpansion(
             """
@@ -50,6 +50,7 @@ final class PolymorphicTransactionConstraintEntryMacroTests: XCTestCase {
                 }
 
                 extension TestConstraint: PolymorphicTransactionConstraintEntry {
+                    typealias AttributesType = TestTypeAStandardTransactionConstraintEntry.AttributesType
                     func handle<Context: PolymorphicWriteEntryContext>(context: Context) throws -> Context.WriteTransactionConstraintType {
                         switch self {
                         case let .testTypeA(writeEntry):
@@ -58,7 +59,7 @@ final class PolymorphicTransactionConstraintEntryMacroTests: XCTestCase {
                             return try context.transform(writeEntry)
                         }
                     }
-                    var compositePrimaryKey: StandardCompositePrimaryKey {
+                    var compositePrimaryKey: CompositePrimaryKey<AttributesType> {
                         switch self {
                         case let .testTypeA(writeEntry):
                             return writeEntry.compositePrimaryKey
@@ -67,10 +68,18 @@ final class PolymorphicTransactionConstraintEntryMacroTests: XCTestCase {
                         }
                     }
                     private static func _assertCase_testTypeA() {
-                        _assertPolymorphicTransactionConstraintEntryParameter(TestTypeAStandardTransactionConstraintEntry.self)
+                        func _check<R: Codable & Sendable, T: TimeToLiveAttributes>(
+                        _: TransactionConstraintEntry<AttributesType, R, T>.Type
+                        ) {
+                        }
+                        _check(TestTypeAStandardTransactionConstraintEntry.self)
                     }
                     private static func _assertCase_testTypeB() {
-                        _assertPolymorphicTransactionConstraintEntryParameter(TestTypeBStandardTransactionConstraintEntry.self)
+                        func _check<R: Codable & Sendable, T: TimeToLiveAttributes>(
+                        _: TransactionConstraintEntry<AttributesType, R, T>.Type
+                        ) {
+                        }
+                        _check(TestTypeBStandardTransactionConstraintEntry.self)
                     }
                 }
                 """,

--- a/Tests/DynamoDBTablesMacrosTests/PolymorphicWriteEntryMacroTests.swift
+++ b/Tests/DynamoDBTablesMacrosTests/PolymorphicWriteEntryMacroTests.swift
@@ -32,12 +32,13 @@ final class PolymorphicWriteEntryMacroTests: XCTestCase {
         )
     ]
 
-    // The expansion includes per-case `_assertCase_*` helpers that force a compile-time check
-    // that the case parameter is a `WriteEntry<...>`. In real builds the helpers wrap their
-    // assertion call in `#sourceLocation(file:, line:)` so the diagnostic surfaces at the
-    // user's case declaration; `BasicMacroExpansionContext` (used by `assertMacroExpansion`)
-    // returns nil from `location(of:)` for detached nodes, so the test goldens see the
-    // fallback (no `#sourceLocation` directives) path.
+    // The expansion derives `AttributesType` from the first case's parameter type and emits
+    // per-case `_assertCase_*` helpers that pin each case parameter to
+    // `WriteEntry<AttributesType, _, _>`. The pin catches both "wrong parameter shape" and
+    // "case attributes don't match the enum's" at the user's case declaration. In real builds
+    // the helpers wrap their assertion in `#sourceLocation(file:, line:)`; `BasicMacroExpansionContext`
+    // (used by `assertMacroExpansion`) returns nil from `location(of:)` for detached nodes, so
+    // the test goldens see the fallback (no `#sourceLocation` directives) path.
     func testExpansionWithTwoCases() {
         assertMacroExpansion(
             """
@@ -54,6 +55,7 @@ final class PolymorphicWriteEntryMacroTests: XCTestCase {
                 }
 
                 extension TestEntry: PolymorphicWriteEntry {
+                    typealias AttributesType = TestTypeAWriteEntry.AttributesType
                     func handle<Context: PolymorphicWriteEntryContext>(context: Context) throws -> Context.WriteEntryTransformType {
                         switch self {
                         case let .testTypeA(writeEntry):
@@ -62,7 +64,7 @@ final class PolymorphicWriteEntryMacroTests: XCTestCase {
                             return try context.transform(writeEntry)
                         }
                     }
-                    var compositePrimaryKey: StandardCompositePrimaryKey {
+                    var compositePrimaryKey: CompositePrimaryKey<AttributesType> {
                         switch self {
                         case let .testTypeA(writeEntry):
                             return writeEntry.compositePrimaryKey
@@ -71,10 +73,18 @@ final class PolymorphicWriteEntryMacroTests: XCTestCase {
                         }
                     }
                     private static func _assertCase_testTypeA() {
-                        _assertPolymorphicWriteEntryParameter(TestTypeAWriteEntry.self)
+                        func _check<R: Codable & Sendable, T: TimeToLiveAttributes>(
+                        _: WriteEntry<AttributesType, R, T>.Type
+                        ) {
+                        }
+                        _check(TestTypeAWriteEntry.self)
                     }
                     private static func _assertCase_testTypeB() {
-                        _assertPolymorphicWriteEntryParameter(TestTypeBWriteEntry.self)
+                        func _check<R: Codable & Sendable, T: TimeToLiveAttributes>(
+                        _: WriteEntry<AttributesType, R, T>.Type
+                        ) {
+                        }
+                        _check(TestTypeBWriteEntry.self)
                     }
                 }
                 """,

--- a/Tests/DynamoDBTablesTests/TestConfiguration.swift
+++ b/Tests/DynamoDBTablesTests/TestConfiguration.swift
@@ -78,3 +78,39 @@ enum TestPolymorphicTransactionConstraintEntry {
     case testTypeA(TestTypeAStandardTransactionConstraintEntry)
     case testTypeB(TestTypeBStandardTransactionConstraintEntry)
 }
+
+// Lock in that the macros work with non-Standard `PrimaryKeyAttributes` end-to-end. The rest of
+// the test suite uses `Standard*` everywhere; these fixtures exist purely to verify the
+// polymorphic behaviour of the macros.
+struct CustomPrimaryKeyAttributes: PrimaryKeyAttributes {
+    static var partitionKeyAttributeName: String { "CustomPK" }
+    static var sortKeyAttributeName: String { "CustomSK" }
+}
+
+typealias CustomAttributesWriteEntry<ItemType: Codable & Sendable> = WriteEntry<
+    CustomPrimaryKeyAttributes, ItemType, StandardTimeToLiveAttributes
+>
+typealias CustomAttributesTransactionConstraintEntry<ItemType: Codable & Sendable> = TransactionConstraintEntry<
+    CustomPrimaryKeyAttributes, ItemType, StandardTimeToLiveAttributes
+>
+typealias CustomAttributesTypedDatabaseItem<RowType: Codable & Sendable> = TypedTTLDatabaseItem<
+    CustomPrimaryKeyAttributes, RowType, StandardTimeToLiveAttributes
+>
+
+@PolymorphicWriteEntry
+enum CustomAttributesPolymorphicWriteEntry {
+    case testTypeA(CustomAttributesWriteEntry<TestTypeA>)
+    case testTypeB(CustomAttributesWriteEntry<TestTypeB>)
+}
+
+@PolymorphicTransactionConstraintEntry
+enum CustomAttributesPolymorphicTransactionConstraintEntry {
+    case testTypeA(CustomAttributesTransactionConstraintEntry<TestTypeA>)
+    case testTypeB(CustomAttributesTransactionConstraintEntry<TestTypeB>)
+}
+
+@PolymorphicOperationReturnType
+enum CustomAttributesQueryableTypes {
+    case testTypeA(CustomAttributesTypedDatabaseItem<TestTypeA>)
+    case testTypeB(CustomAttributesTypedDatabaseItem<TestTypeB>)
+}

--- a/Tests/DynamoDBTablesTests/TestConfiguration.swift
+++ b/Tests/DynamoDBTablesTests/TestConfiguration.swift
@@ -79,22 +79,26 @@ enum TestPolymorphicTransactionConstraintEntry {
     case testTypeB(TestTypeBStandardTransactionConstraintEntry)
 }
 
-// Lock in that the macros work with non-Standard `PrimaryKeyAttributes` end-to-end. The rest of
-// the test suite uses `Standard*` everywhere; these fixtures exist purely to verify the
-// polymorphic behaviour of the macros.
+// Lock in that the macros work with non-Standard `PrimaryKeyAttributes` and `TimeToLiveAttributes`
+// end-to-end. The rest of the test suite uses `Standard*` everywhere; these fixtures exist purely
+// to verify the polymorphic behaviour of the macros.
 struct CustomPrimaryKeyAttributes: PrimaryKeyAttributes {
     static var partitionKeyAttributeName: String { "CustomPK" }
     static var sortKeyAttributeName: String { "CustomSK" }
 }
 
+struct CustomTimeToLiveAttributes: TimeToLiveAttributes {
+    static var timeToLiveAttributeName: String { "CustomTTL" }
+}
+
 typealias CustomAttributesWriteEntry<ItemType: Codable & Sendable> = WriteEntry<
-    CustomPrimaryKeyAttributes, ItemType, StandardTimeToLiveAttributes
+    CustomPrimaryKeyAttributes, ItemType, CustomTimeToLiveAttributes
 >
 typealias CustomAttributesTransactionConstraintEntry<ItemType: Codable & Sendable> = TransactionConstraintEntry<
-    CustomPrimaryKeyAttributes, ItemType, StandardTimeToLiveAttributes
+    CustomPrimaryKeyAttributes, ItemType, CustomTimeToLiveAttributes
 >
 typealias CustomAttributesTypedDatabaseItem<RowType: Codable & Sendable> = TypedTTLDatabaseItem<
-    CustomPrimaryKeyAttributes, RowType, StandardTimeToLiveAttributes
+    CustomPrimaryKeyAttributes, RowType, CustomTimeToLiveAttributes
 >
 
 @PolymorphicWriteEntry


### PR DESCRIPTION
The three macros (`@PolymorphicWriteEntry`, `@PolymorphicTransactionConstraintEntry`, `@PolymorphicOperationReturnType`) previously emitted `StandardCompositePrimaryKey` / `StandardPrimaryKeyAttributes` / `StandardTimeToLiveAttributes` directly, locking conforming enums to those attribute types even though the underlying protocols have always been polymorphic.

Each macro now derives the enum-level `AttributesType` (plus `TimeToLiveAttributesType` for the return-type macro) from the first case parameter via associated types — extending `_PolymorphicReturnTypeCaseParameter` and adding new `_PolymorphicWriteEntryCaseParameter` / `_PolymorphicTransactionConstraintEntryCaseParameter` conformances on `WriteEntry` / `TransactionConstraintEntry`. Subsequent cases must agree: the per-case `_assertCase_*` helper emits an inline `_check` function pinned to the enum's typealiases, so a parameter that's the wrong shape *or* has mismatched attributes surfaces a diagnostic anchored at the user's case line. The `#sourceLocation` directive is placed immediately before the call site so the pretty-printer's line wrapping doesn't drift the anchor.

The previously-public `_assertPolymorphic*` helper functions are removed in favour of the macro-emitted inline `_check` (the constraint shape now lives next to the typealiases it pins).

Live `CustomPrimaryKeyAttributes` fixtures are added to `TestConfiguration.swift` to lock in end-to-end compilation with non-Standard attributes.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
